### PR TITLE
Impl the standard Error type via thiserror (closes #6)

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,14 +14,15 @@ categories = ["database", "network-programming", "asynchronous"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-neo4rs-macros = { version = "0.2.1", path = "../macros" }
-futures = { version = "0.3.8" }
-tokio = { version = "1.0.1", features = ["full"] }
-bytes = "1.0.0"
 async-trait = "0.1.42"
-deadpool = "0.7.0"
+bytes = "1.0.0"
 chrono = "0.4.19"
+deadpool = "0.7.0"
+futures = { version = "0.3.8" }
 log = "0.4"
+neo4rs-macros = { version = "0.2.1", path = "../macros" }
+thiserror = "1.0.26"
+tokio = { version = "1.0.1", features = ["full"] }
 
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4"] }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -71,7 +71,7 @@ impl ConfigBuilder {
             || self.max_connections.is_none()
             || self.db.is_none()
         {
-            Err(Error::InvalidConfig)
+            Err(Error::InvalidConfig("a config field was None".into()))
         } else {
             //The config attributes are validated before unwrapping
             Ok(Config {

--- a/lib/src/convert.rs
+++ b/lib/src/convert.rs
@@ -9,7 +9,7 @@ impl TryFrom<BoltType> for f64 {
     fn try_from(input: BoltType) -> Result<f64> {
         match input {
             BoltType::Float(t) => Ok(t.value),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -20,7 +20,7 @@ impl TryFrom<BoltType> for i64 {
     fn try_from(input: BoltType) -> Result<i64> {
         match input {
             BoltType::Integer(t) => Ok(t.value),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -31,7 +31,7 @@ impl TryFrom<BoltType> for bool {
     fn try_from(input: BoltType) -> Result<bool> {
         match input {
             BoltType::Boolean(t) => Ok(t.value),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -42,7 +42,7 @@ impl TryFrom<BoltType> for Point2D {
     fn try_from(input: BoltType) -> Result<Point2D> {
         match input {
             BoltType::Point2D(p) => Ok(Point2D::new(p)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -53,7 +53,7 @@ impl TryFrom<BoltType> for std::time::Duration {
     fn try_from(input: BoltType) -> Result<std::time::Duration> {
         match input {
             BoltType::Duration(d) => Ok(d.into()),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -64,7 +64,7 @@ impl TryFrom<BoltType> for chrono::NaiveDate {
     fn try_from(input: BoltType) -> Result<chrono::NaiveDate> {
         match input {
             BoltType::Date(d) => d.try_into(),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -75,7 +75,7 @@ impl TryFrom<BoltType> for chrono::DateTime<chrono::FixedOffset> {
     fn try_from(input: BoltType) -> Result<chrono::DateTime<chrono::FixedOffset>> {
         match input {
             BoltType::DateTime(d) => d.try_into(),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -86,7 +86,7 @@ impl TryFrom<BoltType> for chrono::NaiveDateTime {
     fn try_from(input: BoltType) -> Result<chrono::NaiveDateTime> {
         match input {
             BoltType::LocalDateTime(d) => d.try_into(),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -105,7 +105,7 @@ impl TryFrom<BoltType> for (chrono::NaiveTime, Option<chrono::FixedOffset>) {
                 }
             }
             BoltType::LocalTime(d) => Ok((d.into(), None)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -116,7 +116,7 @@ impl TryFrom<BoltType> for (chrono::NaiveDateTime, String) {
     fn try_from(input: BoltType) -> Result<(chrono::NaiveDateTime, String)> {
         match input {
             BoltType::DateTimeZoneId(date_time_zone_id) => date_time_zone_id.try_into(),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -127,7 +127,7 @@ impl TryFrom<BoltType> for Vec<u8> {
     fn try_from(input: BoltType) -> Result<Vec<u8>> {
         match input {
             BoltType::Bytes(b) => Ok(b.value.to_vec()),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -138,7 +138,7 @@ impl TryFrom<BoltType> for Point3D {
     fn try_from(input: BoltType) -> Result<Point3D> {
         match input {
             BoltType::Point3D(p) => Ok(Point3D::new(p)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -149,7 +149,7 @@ impl TryFrom<BoltType> for Node {
     fn try_from(input: BoltType) -> Result<Node> {
         match input {
             BoltType::Node(n) => Ok(Node::new(n)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -160,7 +160,7 @@ impl TryFrom<BoltType> for Path {
     fn try_from(input: BoltType) -> Result<Path> {
         match input {
             BoltType::Path(n) => Ok(Path::new(n)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -171,7 +171,7 @@ impl TryFrom<BoltType> for Relation {
     fn try_from(input: BoltType) -> Result<Relation> {
         match input {
             BoltType::Relation(r) => Ok(Relation::new(r)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -182,7 +182,7 @@ impl TryFrom<BoltType> for UnboundedRelation {
     fn try_from(input: BoltType) -> Result<UnboundedRelation> {
         match input {
             BoltType::UnboundedRelation(r) => Ok(UnboundedRelation::new(r)),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -192,7 +192,7 @@ impl TryFrom<BoltType> for BoltList {
     fn try_from(input: BoltType) -> Result<BoltList> {
         match input {
             BoltType::List(l) => Ok(l),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -202,7 +202,7 @@ impl TryFrom<BoltType> for BoltString {
     fn try_from(input: BoltType) -> Result<BoltString> {
         match input {
             BoltType::String(s) => Ok(s),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }
@@ -212,7 +212,7 @@ impl TryFrom<BoltType> for String {
     fn try_from(input: BoltType) -> Result<String> {
         match input {
             BoltType::String(t) => Ok(t.value),
-            _ => Err(Error::ConverstionError),
+            _ => Err(Error::ConvertError(input)),
         }
     }
 }

--- a/lib/src/messages.rs
+++ b/lib/src/messages.rs
@@ -114,7 +114,7 @@ impl BoltResponse {
             input if Record::can_parse(version, input.clone()) => {
                 Ok(BoltResponse::RecordMessage(Record::parse(version, input)?))
             }
-            msg => Err(Error::UnknownMessage(format!("unknown message {:?}", msg))),
+            msg => Err(Error::UnknownMessage(format!("{:?}", msg))),
         }
     }
 }

--- a/lib/src/types/binary.rs
+++ b/lib/src/types/binary.rs
@@ -61,10 +61,10 @@ impl BoltBytes {
             MEDIUM => input.borrow_mut().get_u16() as usize,
             LARGE => input.borrow_mut().get_u32() as usize,
             _ => {
-                return Err(Error::InvalidTypeMarker(format!(
-                    "invalid bytes marker {}",
-                    marker
-                )))
+                return Err(Error::InvalidTypeMarker {
+                    type_name: "bytes",
+                    marker,
+                })
             }
         };
 

--- a/lib/src/types/boolean.rs
+++ b/lib/src/types/boolean.rs
@@ -37,7 +37,10 @@ impl BoltBoolean {
         match value {
             TRUE => Ok(BoltBoolean::new(true)),
             FALSE => Ok(BoltBoolean::new(false)),
-            _ => Err(Error::InvalidTypeMarker("invalid boolean marker".into())),
+            marker => Err(Error::InvalidTypeMarker {
+                type_name: "boolean",
+                marker,
+            }),
         }
     }
 }

--- a/lib/src/types/date.rs
+++ b/lib/src/types/date.rs
@@ -26,7 +26,7 @@ impl TryInto<NaiveDate> for BoltDate {
         let days = Duration::days(self.days.value);
         epoch
             .checked_add_signed(days)
-            .ok_or(Error::ConverstionError)
+            .ok_or(Error::DateConvertError(self.clone()))
     }
 }
 

--- a/lib/src/types/integer.rs
+++ b/lib/src/types/integer.rs
@@ -56,7 +56,12 @@ impl BoltInteger {
             INT_16 => input.get_i16() as i64,
             INT_32 => input.get_i32() as i64,
             INT_64 => input.get_i64() as i64,
-            _ => return Err(Error::InvalidTypeMarker("invalid integer marker".into())),
+            marker => {
+                return Err(Error::InvalidTypeMarker {
+                    type_name: "integer",
+                    marker,
+                })
+            }
         };
 
         Ok(BoltInteger::new(value))

--- a/lib/src/types/list.rs
+++ b/lib/src/types/list.rs
@@ -123,10 +123,10 @@ impl BoltList {
             MEDIUM => input.borrow_mut().get_u16() as usize,
             LARGE => input.borrow_mut().get_u32() as usize,
             _ => {
-                return Err(Error::InvalidTypeMarker(format!(
-                    "invalid list marker {}",
-                    marker
-                )))
+                return Err(Error::InvalidTypeMarker {
+                    type_name: "list",
+                    marker,
+                })
             }
         };
 

--- a/lib/src/types/map.rs
+++ b/lib/src/types/map.rs
@@ -122,10 +122,10 @@ impl BoltMap {
             MEDIUM => input.borrow_mut().get_u16() as usize,
             LARGE => input.borrow_mut().get_u32() as usize,
             _ => {
-                return Err(Error::InvalidTypeMarker(format!(
-                    "invalid map marker {}",
-                    marker
-                )))
+                return Err(Error::InvalidTypeMarker {
+                    type_name: "map",
+                    marker,
+                })
             }
         };
 

--- a/lib/src/types/string.rs
+++ b/lib/src/types/string.rs
@@ -91,15 +91,15 @@ impl BoltString {
             MEDIUM => input.get_u16() as usize,
             LARGE => input.get_u32() as usize,
             _ => {
-                return Err(Error::InvalidTypeMarker(format!(
-                    "invalid string marker {}",
-                    marker
-                )))
+                return Err(Error::InvalidTypeMarker {
+                    type_name: "string",
+                    marker,
+                })
             }
         };
         let byte_array = input.split_to(length).to_vec();
         let string_value = std::string::String::from_utf8(byte_array)
-            .map_err(|e| Error::DeserializationError(e.to_string()))?;
+            .map_err(Error::DeserializationError)?;
         Ok(string_value.into())
     }
 }

--- a/lib/src/version.rs
+++ b/lib/src/version.rs
@@ -23,10 +23,7 @@ impl Version {
         match u32::from_be_bytes(version_bytes) {
             260 => Ok(Version::V4_1),
             4 => Ok(Version::V4),
-            v => Err(Error::UnsupportedVersion(format!(
-                "version {} is not supported",
-                v
-            ))),
+            v => Err(Error::UnsupportedVersion(v)),
         }
     }
 }


### PR DESCRIPTION
I've attempted to address #6 by using `thiserror` to generate the necessary impls for the crate's error type to conform to the standard `Error` type. Edits by maintainers are on, so feel free to edit anything that needs bikeshedding.